### PR TITLE
update zip.go:  Close docx template file handler on exit

### DIFF
--- a/internal/zip.go
+++ b/internal/zip.go
@@ -131,6 +131,9 @@ func (za *ZipArchive) Close() error {
 			return err
 		}
 	}
-
+	
+	if err := za.reader.Close(); err != nil {
+		return err
+	}
 	return za.writer.Close()
 }

--- a/internal/zip.go
+++ b/internal/zip.go
@@ -102,6 +102,8 @@ func (za *ZipArchive) GetFile(name string) ([]byte, error) {
 }
 
 func (za *ZipArchive) Close() error {
+	defer za.reader.Close()
+	
 	names := make([]string, len(za.files))
 	i := 0
 	for name, data := range za.files {
@@ -132,8 +134,5 @@ func (za *ZipArchive) Close() error {
 		}
 	}
 	
-	if err := za.reader.Close(); err != nil {
-		return err
-	}
 	return za.writer.Close()
 }


### PR DESCRIPTION
Close docx template file handler on exit from **(za *ZipArchive) Close()** method to prevent template file locking in long running services.