### PR TITLE
CreateReport(): add deferred cleanup (closing zip r/w) to prevent r/w locks on early returns

### DIFF
--- a/internal/zip.go
+++ b/internal/zip.go
@@ -101,9 +101,8 @@ func (za *ZipArchive) GetFile(name string) ([]byte, error) {
 	return data, nil
 }
 
-func (za *ZipArchive) Close() error {
-	defer za.reader.Close()
-	
+func (za *ZipArchive) Assemble() error {
+
 	names := make([]string, len(za.files))
 	i := 0
 	for name, data := range za.files {
@@ -134,5 +133,10 @@ func (za *ZipArchive) Close() error {
 		}
 	}
 	
+	return nil
+}
+
+func (za *ZipArchive) Close() error {
+	za.reader.Close()
 	return za.writer.Close()
 }

--- a/report.go
+++ b/report.go
@@ -25,7 +25,7 @@ const (
 // Returns:
 //   - A byte slice representing the generated document.
 //   - An error if any occurs during template parsing, processing, or document generation.
-func CreateReport(templatePath string, data *ReportData, options CreateReportOptions) (outBytes []byte, err error) { {
+func CreateReport(templatePath string, data *ReportData, options CreateReportOptions) (outBytes []byte, err error) {
 	
 	outBuffer := bytes.NewBuffer(outBytes)
 	zip, err := internal.NewZipArchive(templatePath, outBuffer)
@@ -34,8 +34,7 @@ func CreateReport(templatePath string, data *ReportData, options CreateReportOpt
 	}
 	doCleanupOnDefer := true
 	defer func() {
-		// only do cleanup on early returns:
-		if doCleanupOnDefer {
+		if doCleanupOnDefer { // only do cleanup on early returns
 			errOnClose := zip.Close()
 			err = errors.Join(err, errOnClose)
 		}

--- a/report.go
+++ b/report.go
@@ -25,13 +25,21 @@ const (
 // Returns:
 //   - A byte slice representing the generated document.
 //   - An error if any occurs during template parsing, processing, or document generation.
-func CreateReport(templatePath string, data *ReportData, options CreateReportOptions) ([]byte, error) {
-
-	outBuffer := new(bytes.Buffer)
+func CreateReport(templatePath string, data *ReportData, options CreateReportOptions) (outBytes []byte, err error) { {
+	
+	outBuffer := bytes.NewBuffer(outBytes)
 	zip, err := internal.NewZipArchive(templatePath, outBuffer)
 	if err != nil {
 		return nil, err
 	}
+	doCleanupOnDefer := true
+	defer func() {
+		// only do cleanup on early returns:
+		if doCleanupOnDefer {
+			errOnClose := zip.Close()
+			err = errors.Join(err, errOnClose)
+		}
+	}()
 
 	// xml parse the document
 	parseResult, err := internal.ParseTemplate(zip)
@@ -131,9 +139,16 @@ func CreateReport(templatePath string, data *ReportData, options CreateReportOpt
 		zip.SetFile(CONTENT_TYPES_PATH, finalContentTypesXml)
 	}
 
-	err = zip.Close()
+	err = zip.Assemble()
 	if err != nil {
-		return nil, fmt.Errorf("Error closing zip : %w", err)
+		return nil, fmt.Errorf("Error assembling zip: %w", err)
 	}
+
+	err = zip.Close()
+	doCleanupOnDefer = false // zip was closed here by code path, no special cleanup needed
+	if err != nil {
+		return nil, fmt.Errorf("Error closing zip: %w", err)
+	}
+
 	return outBuffer.Bytes(), nil
 }

--- a/report.go
+++ b/report.go
@@ -2,6 +2,7 @@ package godocx
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"

--- a/report_test.go
+++ b/report_test.go
@@ -138,6 +138,43 @@ func TestCreateReport(t *testing.T) {
 		})
 	})
 
+	// Test if zip.Reader is closed on early returns
+	t.Run("Test if zip.Reader is closed on early returns", func(t *testing.T) {
+		data := ReportData{}
+
+		// This template is intentionally non-valid to produce an error (with early return from CreateReport())
+		templateContent := []byte(`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+			<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+				<w:body>
+					<w:p>
+						<w:r>
+							<w:t>+++this_throws_error+++</w:t>
+						</w:r>
+					</w:p>
+				</w:body>
+			</w:document>`)
+		err := createTestDocx(templateContent, "test_template.docx")
+		if err != nil {
+			t.Fatalf("Failed to create test template: %v", err)
+		}
+		defer os.Remove("test_template.docx")
+
+		// Run test
+		options := CreateReportOptions{
+			LiteralXmlDelimiter: "||",
+		}
+
+		// This will return an error, because template is not valid:
+		_, err = CreateReport("test_template.docx", &data, options)
+
+		// Now we have to ensure that CreateReport() closed(unlocked) template file on early return:
+		err = os.Remove("test_template.docx")
+		if err != nil {
+			t.Fatalf("Removing docx template file failed: %v", err)
+		}
+		
+	})
+	
 	// Test image processing
 	t.Run("image processing", func(t *testing.T) {
 		imageData := []byte{


### PR DESCRIPTION
1) Split zip.Close() into zip.Assemble() and zip.Close()
2) Use those in CreateReport() to prevent r/w locks on early returns
3) Add test to ensure no lock happenes